### PR TITLE
Run tests on GitHub

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -9,7 +9,24 @@ on:
 concurrency: tests-in-single-folder
 
 jobs:
-  build-and-test:
+  build:
+    runs-on: ubuntu-20.04
+    env:
+      APP_ENV: production
+    steps:
+      - uses: yandex-cloud/nodejs-sdk/.github/actions/checkout-and-install-node@f69248b52b7991214847e889f28ba0883ed0ca2c
+      - run: npm run cdktf:get
+      - run: npm run build
+      - uses: actions/upload-artifact@v3
+        with:
+          name: dist
+          path: dist
+
+  test:
+    needs: build
+    # Skip for PRs from forks as secrets are not available there
+    # See: https://github.com/orgs/community/discussions/26829
+    if: github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     runs-on: ubuntu-20.04
     env:
       YC_CLOUD_ID: ${{ secrets.YC_CLOUD_ID }}
@@ -17,11 +34,12 @@ jobs:
       YC_SERVICE_ACCOUNT_KEY_FILE: ${{ secrets.YC_SERVICE_ACCOUNT_KEY_FILE }}
     steps:
       - uses: yandex-cloud/nodejs-sdk/.github/actions/checkout-and-install-node@f69248b52b7991214847e889f28ba0883ed0ca2c
-      - run: npm run cdktf:get
-      - run: APP_ENV=production npm run build
+      - uses: actions/download-artifact@v3
+        with:
+          name: dist
+          path: dist
       - id: deploy
         run: node ./dist/cli.js deploy --auto-approve
       - run: npm run test
       - if: steps.deploy.outcome == 'success'
         run: node ./dist/cli.js destroy --auto-approve
-

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -5,14 +5,20 @@ on:
       - master
       - alpha
       - beta
+
 jobs:
   build-and-test:
     runs-on: ubuntu-20.04
+    env:
+      YC_CLOUD_ID: ${{ secrets.YC_CLOUD_ID }}
+      YC_FOLDER_ID: ${{ secrets.YC_FOLDER_ID }}
+      YC_SERVICE_ACCOUNT_KEY_FILE: ${{ secrets.YC_SERVICE_ACCOUNT_KEY_FILE }}
     steps:
       - uses: yandex-cloud/nodejs-sdk/.github/actions/checkout-and-install-node@f69248b52b7991214847e889f28ba0883ed0ca2c
       - run: npm run cdktf:get
-      - run: npm run example:deploy
+      - run: APP_ENV=production npm run build
+      - run: node ./dist/cli.js deploy --auto-approve
       - run: npm run test
-      - run: node ./dist/cli.js destroy
-        if: always()
+      # - if: always()
+      #   run: node ./dist/cli.js destroy
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -17,8 +17,9 @@ jobs:
       - uses: yandex-cloud/nodejs-sdk/.github/actions/checkout-and-install-node@f69248b52b7991214847e889f28ba0883ed0ca2c
       - run: npm run cdktf:get
       - run: APP_ENV=production npm run build
-      - run: node ./dist/cli.js deploy --auto-approve
+      - id: deploy
+        run: node ./dist/cli.js deploy --auto-approve
       - run: npm run test
-      # - if: always()
-      #   run: node ./dist/cli.js destroy
+      - if: steps.deploy.outcome == 'success'
+        run: node ./dist/cli.js destroy --auto-approve
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -6,8 +6,13 @@ on:
       - alpha
       - beta
 jobs:
-  build:
+  build-and-test:
     runs-on: ubuntu-20.04
     steps:
       - uses: yandex-cloud/nodejs-sdk/.github/actions/checkout-and-install-node@f69248b52b7991214847e889f28ba0883ed0ca2c
-      - run: npm run cdktf:get && npm run build
+      - run: npm run cdktf:get
+      - run: npm run example:deploy
+      - run: npm run test
+      - run: node ./dist/cli.js destroy
+        if: always()
+

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -6,6 +6,8 @@ on:
       - alpha
       - beta
 
+concurrency: tests-in-single-folder
+
 jobs:
   build-and-test:
     runs-on: ubuntu-20.04

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -6,8 +6,6 @@ on:
       - alpha
       - beta
 
-concurrency: tests-in-single-folder
-
 jobs:
   build:
     runs-on: ubuntu-20.04
@@ -27,6 +25,7 @@ jobs:
     # Skip for PRs from forks as secrets are not available there
     # See: https://github.com/orgs/community/discussions/26829
     if: github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+    concurrency: tests-in-single-folder
     runs-on: ubuntu-20.04
     env:
       YC_CLOUD_ID: ${{ secrets.YC_CLOUD_ID }}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "cdktf:get": "npx cdktf get --output src/local-client/.gen",
     "lint": "eslint src test",
     "lint:fix": "npm run lint -- --fix",
-    "test": "LOG_LEVEL=${LOG_LEVEL:-error} mocha -r ts-node/register test/*.spec.ts -t 10000",
+    "test": "LOG_LEVEL=${LOG_LEVEL:-error} mocha -r ts-node/register test/*.spec.ts",
     "test:d": "LOG_LEVEL=debug npm t",
     "example:deploy": "APP_ENV=production npm run build && node ./dist/cli.js deploy",
     "example:run": "node ./dist/cli.js run -c example/live-debug.config.ts",

--- a/src/local-client/cdktf/apigw.ts
+++ b/src/local-client/cdktf/apigw.ts
@@ -14,7 +14,7 @@ export class Apigw extends Construct {
     this.instance = new ApiGateway(this, 'gateway', {
       name: this.title,
       description: 'API gateway to hold WS connections and accept stub function requests',
-      folderId: scope.folder.id,
+      folderId: scope.folderId,
       spec: this.createSpec(),
     });
   }

--- a/src/local-client/cdktf/main.ts
+++ b/src/local-client/cdktf/main.ts
@@ -32,7 +32,7 @@ export function main() {
 }
 
 export class LiveDebugStack extends TerraformStack {
-  folder: ResourcemanagerFolder;
+  folderId: string;
   sa: Sa;
   ydb: YdbDatabaseServerless;
   stub: Stub;
@@ -43,7 +43,7 @@ export class LiveDebugStack extends TerraformStack {
     super(scope, id);
     this.initBackend();
     this.initProvider();
-    this.folder = this.createFolder();
+    this.folderId = this.getFolderId();
     this.sa = this.createSa();
     this.ydb = this.createYdb();
     this.stub = this.createStub();
@@ -66,10 +66,12 @@ export class LiveDebugStack extends TerraformStack {
     });
   }
 
-  private createFolder() {
-    return new ResourcemanagerFolder(this, 'folder', {
-      name: this.config.folderName,
-    });
+  private getFolderId() {
+    return process.env.YC_FOLDER_ID
+      ? process.env.YC_FOLDER_ID
+      : new ResourcemanagerFolder(this, 'folder', {
+          name: this.config.folderName,
+        }).id;
   }
 
   private createSa() {
@@ -95,7 +97,7 @@ export class LiveDebugStack extends TerraformStack {
   private createYdb() {
     return new YdbDatabaseServerless(this, 'ydb', {
       name: 'live-debug-db',
-      folderId: this.folder.id,
+      folderId: this.folderId,
     });
   }
 

--- a/src/local-client/cdktf/main.ts
+++ b/src/local-client/cdktf/main.ts
@@ -60,6 +60,7 @@ export class LiveDebugStack extends TerraformStack {
 
   private initProvider() {
     new YandexProvider(this, 'provider', {
+      // Only one of token or service_account_key_file must be specified.
       token: process.env.YC_TOKEN,
       serviceAccountKeyFile: process.env.YC_SERVICE_ACCOUNT_KEY_FILE,
       cloudId: process.env.YC_CLOUD_ID,
@@ -67,11 +68,9 @@ export class LiveDebugStack extends TerraformStack {
   }
 
   private getFolderId() {
-    return process.env.YC_FOLDER_ID
-      ? process.env.YC_FOLDER_ID
-      : new ResourcemanagerFolder(this, 'folder', {
-          name: this.config.folderName,
-        }).id;
+    return process.env.YC_FOLDER_ID ?? new ResourcemanagerFolder(this, 'folder', {
+      name: this.config.folderName,
+    }).id;
   }
 
   private createSa() {

--- a/src/local-client/cdktf/sa.ts
+++ b/src/local-client/cdktf/sa.ts
@@ -10,9 +10,9 @@ export class Sa extends Construct {
     super(scope, name);
     this.instance = new IamServiceAccount(this, 'sa', {
       // sa name should be unique
-      name: `${this.scope.folder.id}-sa`,
+      name: `${this.scope.folderId}-sa`,
       description: 'Service account for live debug',
-      folderId: this.scope.folder.id,
+      folderId: this.scope.folderId,
     });
     this.createRoles([
       'serverless.functions.invoker',
@@ -29,7 +29,7 @@ export class Sa extends Construct {
     roles.forEach(role => {
       new ResourcemanagerFolderIamBinding(this, role, {
         members: [ `serviceAccount:${this.id}` ],
-        folderId: this.scope.folder.id,
+        folderId: this.scope.folderId,
         role,
       });
     });

--- a/src/local-client/cdktf/sa.ts
+++ b/src/local-client/cdktf/sa.ts
@@ -10,7 +10,7 @@ export class Sa extends Construct {
     super(scope, name);
     this.instance = new IamServiceAccount(this, 'sa', {
       // sa name should be unique
-      name: `${this.scope.folderId}-sa`,
+      name: `sa-live-debug-${this.scope.folderId}`,
       description: 'Service account for live debug',
       folderId: this.scope.folderId,
     });

--- a/src/local-client/cdktf/store.ts
+++ b/src/local-client/cdktf/store.ts
@@ -20,7 +20,7 @@ export class Store extends Construct {
       entrypoint: 'index.handler',
       memory: 1024,
       executionTimeout: '5',
-      folderId: scope.folder.id,
+      folderId: scope.folderId,
       serviceAccountId: scope.sa.id,
       userHash: zip.assetHash,
       content: {

--- a/src/local-client/cdktf/stub.ts
+++ b/src/local-client/cdktf/stub.ts
@@ -23,7 +23,7 @@ export class Stub extends Construct {
       entrypoint: 'index.handler',
       memory: 1024,
       executionTimeout: '60',
-      folderId: scope.folder.id,
+      folderId: scope.folderId,
       serviceAccountId: scope.sa.id,
       userHash: zip.assetHash,
       content: {

--- a/test/e2e.spec.ts
+++ b/test/e2e.spec.ts
@@ -15,7 +15,9 @@ if (!fs.existsSync(outputsFile)) {
   process.exit(1);
 }
 
-describe('live debug', () => {
+describe('live debug', function () {
+
+  this.timeout(process.env.CI ? 20_000 : 10_000);
 
   afterEach(async () => {
     await localClient?.close();


### PR DESCRIPTION
Добавил запуск тестов на ci, по мотивам https://github.com/yandex-cloud/yc-serverless-live-debug/issues/15. Проверял на своем форке, в итоге все [завелось](https://github.com/vitalets/yc-serverless-live-debug/actions/workflows/pr-checks.yml).
Сервисному аккаунту пришлось выдать роль `admin` на папку, при `editor` он ругается на этапе выдаче прав.
Может можно как-то более специфично админа выдать?

@DavyJohnes посмотри плз.